### PR TITLE
Add Unmarshal for db Row => structs.

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,7 +1,11 @@
 package pan
 
 import (
+	"database/sql"
+	"os"
 	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 type testType struct {
@@ -306,4 +310,48 @@ func TestNonStructM2MFieldTypes2(t *testing.T) {
 	}()
 	fields, values := GetM2MFields(&testType{}, "MyString", invalidSqlFieldReflector("test"), "ID")
 	t.Errorf("Expected a panic, got `%v` and `%v` instead.", fields, values)
+}
+
+func TestUnmarshal(t *testing.T) {
+	os.Remove("./test.db")
+
+	db, err := sql.Open("sqlite3", "./test.db")
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+
+	dummy := testType{
+		myInt:          1,
+		MyTaggedInt:    12,
+		MyString:       "test",
+		myTaggedString: "tagged",
+		OmittedColumn:  "hide",
+	}
+	expectation := testType{}
+	_, err = db.Exec("create table test_types (tagged_int integer, my_string varchar);")
+	if err != nil {
+		t.Error(err)
+	}
+	fields, values := GetQuotedFields(dummy)
+	q := New(MYSQL, "INSERT INTO "+GetTableName(dummy))
+	q.Include("(" + QueryList(fields) + ")")
+	q.Include("VALUES")
+	q.Include("("+VariableList(len(values))+")", values...)
+	q.FlushExpressions(" ")
+	_, err = db.Exec(q.String(), q.Args...)
+	if err != nil {
+		t.Error(err)
+	}
+	row := db.QueryRow("SELECT * FROM test_types;")
+	err = Unmarshal(row, &expectation)
+	if err != nil {
+		t.Error(err)
+	}
+	if expectation.MyTaggedInt != dummy.MyTaggedInt {
+		t.Errorf("Expected MyTaggedInt to be %d, was %d.", dummy.MyTaggedInt, expectation.MyTaggedInt)
+	}
+	if expectation.MyString != dummy.MyString {
+		t.Errorf("Expected MyString to be %s, was %s.", dummy.MyString, expectation.MyString)
+	}
 }


### PR DESCRIPTION
Add an Unmarshal function that takes a sql.Row or sql.Rows (technically,
anything with a Scan function) and an interface as an argument. It will
then attempt to map the database results to the struct fields.

This is the mirror to getFields; getFields returns a list of the fields
and their values suitable for use in queries. Unmarshal sets the fields
to values provided by database rows. It will correctly skip unexported
fields and fields not stored in the database.
