### PR TITLE
Update our license structure.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,11 @@
+# This is the official list of pan authors for copyright purposes.
+#
+# Names should be added to this file as one of
+#     Organization's name
+#     Organization's name <submission email address> <email2> <emailN>
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+#
+# Emails, where supplied and possible, should be those tied to the commits that the author has a copyright claim on.
+
+Impractical Labs <paddy@impractical.co> <paddy@paddy.io> <paddy@secondbit.org> <foran.paddy@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Portions Copyright (c) 2013 Second Bit
+Portions Copyright (c) 2014 The pan Authors
 Portions Copyright (c) 2014 DramaFever, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
We're now declaring copyright belongs to the pan authors, and adding an
authors file showing the list of people who have a copyright claim.

My understanding is that DramaFever would like to opt-out of this
structure, and so I've left them in their spot in the LICENSE file,
instead of moving their claim to the AUTHORS file.