### PR TITLE
Add the ability to buffer complex expressions

### DIFF
--- a/query.go
+++ b/query.go
@@ -175,13 +175,13 @@ func (q *Query) PostgreSQLString() (string, error) {
 	return res + ";", nil
 }
 
-// SubQuery starts a Query with a new buffer, so it can be flushed without
-// affecting the outer Query's buffer of expressions.
+// ComplexExpression starts a Query with a new buffer, so it can be flushed
+// without affecting the outer Query's buffer of expressions.
 //
-// Once a SubQuery has been flushed, it should have its AppendToParent method
-// called, which sets the entire SubQuery as a single expression on its parent
-// Query.
-func (q *Query) SubQuery(query string) *Query {
+// Once a ComplexExpression has been flushed, it should have its AppendToParent
+// method called, which sets the entire ComplexExpression as a single
+// expression on its parent Query.
+func (q *Query) ComplexExpression(query string) *Query {
 	return &Query{
 		sql:    query,
 		args:   []any{},
@@ -190,13 +190,14 @@ func (q *Query) SubQuery(query string) *Query {
 }
 
 // AppendToParent sets the entire Query as a single expression on its parent
-// Query. It should only be called on Querys created by calling SubQuery;
-// calling it on a Query that isn't a SubQuery will panic.
+// Query. It should only be called on Querys created by calling
+// ComplexExpression; calling it on a Query that isn't a ComplexExpression will
+// panic.
 //
 // It returns the parent of the Query.
 func (q *Query) AppendToParent() *Query {
 	if q.parent == nil {
-		panic("can't call AppendToParent on a Query that wasn't created using Query.SubQuery")
+		panic("can't call AppendToParent on a Query that wasn't created using Query.ComplexExpression")
 	}
 	if len(q.expressions) > 0 {
 		panic(ErrNeedsFlush)


### PR DESCRIPTION
Add a new `ComplexExpressions` method to the `Query` type, which will return a child `Query` instance with its own expression/argument buffer. This is really useful if you want multiple complex comparisons (`(x AND y) OR (a AND b)`) joined together. Without this feature, the first call to `Flush` will empty the buffer, which means the join of the complex expressions won't work because they're no longer buffered.